### PR TITLE
Minor improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ A static site powered by [Jekyll](https://jekyllrb.com/).
 
 ## Getting started
 
-You will need [Node.js](http://nodejs.org/download/) (min v6.10.x), [Ruby](https://www.ruby-lang.org/en/), [Bundler](https://bundler.io/) and [Yarn](https://yarnpkg.com/lang/en/).
+You will need [Node.js](http://nodejs.org/download/) (min v6.10.x), [Ruby](https://www.ruby-lang.org/en/), and [Bundler](https://bundler.io/).
 
 Once these have been installed run:
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Stabile
 
-A static site site generator powered by Jekyll.
+A static site powered by [Jekyll](https://jekyllrb.com/).
 
 
 ## Getting started
@@ -21,11 +21,22 @@ The local site will now be available at [http://localhost:4000/](http://localhos
 npm run start
 ```
 
-The process will start the server and watch for changes, recompiling as necessary. If you add new assets such as fonts or images you will need to manually copy them to the `_site` output by running:
+ The process will start the server and watch for changes, recompiling as necessary. If you add new assets such as fonts or images you will need to manually copy them to the `_site` output by running:
 
 ```
 npm run copy
 ```
+
+The site uses standard Jekyll conventions for templates (markdown) and wrappers (HTML).
+
+CSS is created using [SASS](http://sass-lang.com/) but compiled via the `node-sass` module as this is quicker than using the usual Ruby implementation.
+
+The Javascript can be found in `./views/_includes/_global/document_foot.html`. There is so little on this site that it's more efficient to add it this way than to wrap it in a transpile/bundle process.
+
+
+### HTML Compression
+
+The HTML is compressed by default using the `compress.html` layout. If you would like to disable this then remove the YML front-matter from the `default.html` layout.
 
 
 ## Bundling for deployment
@@ -35,17 +46,3 @@ npm run deploy
 ```
 
 You'll find a deployable bundle in the `_site` directory.
-
-
-## To-do
-[x] Some better docs
-
-
-## Release History
-
-For a full release history, see the [Changelog](https://github.com/donofkarma/stabile/blob/master/CHANGELOG.md).
-
-
-## License
-
-MIT: [https://github.com/donofkarma/stabile/blob/master/LICENSE](https://github.com/donofkarma/stabile/blob/master/LICENSE)

--- a/README.md
+++ b/README.md
@@ -5,11 +5,15 @@ A static site site generator powered by Jekyll.
 
 ## Getting started
 
-To use this generator you will need [Node.js](http://nodejs.org/download/) (min v6.10.x), [Ruby](https://www.ruby-lang.org/en/) and [Yarn](https://yarnpkg.com/lang/en/).
+You will need [Node.js](http://nodejs.org/download/) (min v6.10.x), [Ruby](https://www.ruby-lang.org/en/), [Bundler](https://bundler.io/) and [Yarn](https://yarnpkg.com/lang/en/).
+
+Once these have been installed run:
 
 ```
 bundle install && npm run start
 ```
+
+The local site will now be available at [http://localhost:4000/](http://localhost:4000/).
 
 ## Writing code
 
@@ -17,7 +21,11 @@ bundle install && npm run start
 npm run start
 ```
 
-The local site will be available at [http://localhost:4000/](http://localhost:4000/)
+The process will start the server and watch for changes, recompiling as necessary. If you add new assets such as fonts or images you will need to manually copy them to the `_site` output by running:
+
+```
+npm run copy
+```
 
 
 ## Bundling for deployment
@@ -30,7 +38,7 @@ You'll find a deployable bundle in the `_site` directory.
 
 
 ## To-do
-[] Some better docs
+[x] Some better docs
 
 
 ## Release History

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
         "prewatch": "npm run build",
         "watch": "parallelshell 'npm run watch:html' 'npm run watch:css' 'npm run watch:js'",
 
-        "start": "yarn install && npm run watch"
+        "start": "npm install && npm run watch"
     },
     "engines": {
         "node": ">= 6.10.0"

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
         "predeploy": "NODE_ENV=production npm run build",
         "deploy": "npm run deploy:css",
 
-        "watch:html": "jekyll serve",
+        "watch:html": "jekyll serve --host 0.0.0.0",
         "watch:css": "./node_modules/.bin/node-sass ./src/sass/ --output ./_site/assets/css/ --watch",
         "watch:js": "./node_modules/watchify/bin/cmd.js src/js/script.js --standalone CS -o _site/assets/js/script.js -t babelify -v",
 


### PR DESCRIPTION
- Adding some better docs.
- Allowing both `localhost` and IP address based connections to the Jekyll development server. This means testing on devices is easier on the same network.
- Removing Yarn as a dependency in favour of NPM so there is less friction to use the generator.